### PR TITLE
Convert readme listing to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@ All code in this repository is citable by DOI http://dx.doi.org/10.5281/zenodo.9
 Root directory of the cutout and annotation services.
 Major directories include:
 
-  django -- django project files
-  annotate -- annotation service
-  cutout -- cutout service
-  dbconfig -- description of data sets
-  util -- files used by cutout and annotate
-  examples -- how to use the service
-  admin -- scripts to manage databases
-  scripts -- utilities to build annotation and image stacks
+| Directory   | Description 
+|-------------|:-------------|
+| `django`    | django project files
+| `annotate`  | annotation service
+| `cutout`    | cutout service
+| `dbconfig`  | description of data sets
+| `util`      | files used by cutout and annotate
+| `examples`  | how to use the service
+| `admin`     | scripts to manage databases
+| `scripts`   | utilities to build annotation and image stacks
 
 ### openconnectome/open-connectome now has a Chat Room on Gitter
 


### PR DESCRIPTION
Changes the listing of directories to markdown-table-format for to make great pretty.