### PR TITLE
merge ocpviz to master 

### DIFF
--- a/django/ocpviz/migrations/0013_auto_20150904_1547.py
+++ b/django/ocpviz/migrations/0013_auto_20150904_1547.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ocpviz', '0012_auto_20150710_2158'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='vizproject',
+            old_name='maxres',
+            new_name='scalinglevels',
+        ),
+        migrations.RenameField(
+            model_name='vizproject',
+            old_name='xmax',
+            new_name='ximagesize',
+        ),
+        migrations.RenameField(
+            model_name='vizproject',
+            old_name='xmin',
+            new_name='xoffset',
+        ),
+        migrations.RenameField(
+            model_name='vizproject',
+            old_name='ymax',
+            new_name='yimagesize',
+        ),
+        migrations.RenameField(
+            model_name='vizproject',
+            old_name='ymin',
+            new_name='yoffset',
+        ),
+        migrations.RenameField(
+            model_name='vizproject',
+            old_name='zmax',
+            new_name='zimagesize',
+        ),
+        migrations.RenameField(
+            model_name='vizproject',
+            old_name='zmin',
+            new_name='zoffset',
+        ),
+        migrations.RemoveField(
+            model_name='vizlayer',
+            name='required',
+        ),
+        migrations.AlterField(
+            model_name='vizlayer',
+            name='channel',
+            field=models.CharField(max_length=255),
+        ),
+    ]

--- a/django/ocpviz/models.py
+++ b/django/ocpviz/models.py
@@ -44,9 +44,7 @@ class VizLayer ( models.Model ):
   )
   layertype = models.CharField(max_length=255, choices=LAYER_CHOICES)
   token = models.CharField(max_length=255)
-  channel = models.CharField(max_length=255, blank=True)
-  # prevent the user from turning off EM data
-  required = models.BooleanField(default=False) 
+  channel = models.CharField(max_length=255)
   # do we want to use the tilecache or ocpcatmaid? (default ocpcatmaid)  
   tilecache = models.BooleanField(default=False) 
   # for mcfc cutout 
@@ -77,18 +75,18 @@ class VizProject ( models.Model ):
   layers = models.ManyToManyField(VizLayer, related_name='project')
 
 
-  xmin = models.IntegerField(default=0)
-  xmax = models.IntegerField()
-  ymin = models.IntegerField(default=0)
-  ymax = models.IntegerField()
-  zmin = models.IntegerField(default=0)
-  zmax = models.IntegerField()
+  xoffset = models.IntegerField(default=0)
+  ximagesize = models.IntegerField()
+  yoffset = models.IntegerField(default=0)
+  yimagesize = models.IntegerField()
+  zoffset = models.IntegerField(default=0)
+  zimagesize = models.IntegerField()
 
   starttime = models.IntegerField(default=0)
   endtime = models.IntegerField(default=0)
 
   minres = models.IntegerField(default=0)
-  maxres = models.IntegerField()
+  scalinglevels = models.IntegerField()
 
   def __unicode__(self):
     return self.project_name

--- a/django/ocpviz/views.py
+++ b/django/ocpviz/views.py
@@ -210,8 +210,8 @@ def projectview(request, webargs):
   z = None
   res = None
   marker = False
-
-  if len(restsplit) == 4:
+  
+  if len(restsplit) == 5:
     #  res/x/y/z/ args 
     res = int(restsplit[0])
     x = int(restsplit[1])

--- a/django/ocpviz/views.py
+++ b/django/ocpviz/views.py
@@ -234,32 +234,32 @@ def projectview(request, webargs):
       break
 
   # calculate the lowest resolution xmax and ymax
-  xdownmax = (project.xmax - project.xmin)/(2**project.maxres)
-  ydownmax = (project.ymax - project.ymin)/(2**project.maxres)
+  xdownmax = (project.ximagesize - project.xoffset)/(2**project.scalinglevels)
+  ydownmax = (project.yimagesize - project.yoffset)/(2**project.scalinglevels)
   
   if x is None:
     x = xdownmax/2
   if y is None:
     y = ydownmax/2
   if z is None:
-    z = project.zmin
+    z = project.zoffset
   if res is None:
-    res = project.maxres 
+    res = project.scalinglevels 
   
   context = {
       'layers': layers,
       'project_name': project_name,
-      'xsize': project.xmax,
-      'ysize': project.ymax,
-      'zsize': project.zmax,
-      'zstart': project.zmin,
-      'xoffset': project.xmin,
-      'yoffset': project.ymin,
-      'zoffset': project.zmin,
-      'maxres': project.maxres,
+      'xsize': project.ximagesize,
+      'ysize': project.yimagesize,
+      'zsize': project.zimagesize,
+      'zstart': project.zoffset,
+      'xoffset': project.xoffset,
+      'yoffset': project.yoffset,
+      'zoffset': project.zoffset ,
+      'maxres': project.scalinglevels,
       'minres':0,
       'res': res, 
-      'resstart': project.maxres,
+      'resstart': project.scalinglevels,
       'xstart': x,
       'ystart': y,
       'zstart': z,

--- a/django/ocpviz/views.py
+++ b/django/ocpviz/views.py
@@ -219,9 +219,9 @@ def projectview(request, webargs):
     z = int(restsplit[3])
     marker = True 
 
-  else:
-    # return error 
-    return HttpResponseBadRequest('Error: Invalid REST arguments.')
+  #else:
+  #  # return error 
+  #  return HttpResponseBadRequest('Error: Invalid REST arguments.')
   
   # query for the project from the db
   project = get_object_or_404(VizProject, pk=project_name) 
@@ -235,7 +235,7 @@ def projectview(request, webargs):
 
   # calculate the lowest resolution xmax and ymax
   xdownmax = (project.xmax - project.xmin)/(2**project.maxres)
-  xdownmax = (project.ymax - project.ymin)/(2**project.maxres)
+  ydownmax = (project.ymax - project.ymin)/(2**project.maxres)
   
   if x is None:
     x = xdownmax/2

--- a/django/ocpviz/views.py
+++ b/django/ocpviz/views.py
@@ -45,7 +45,29 @@ VALID_SERVERS = {
 QUERY_TYPES = ['ANNOS']
 
 def default(request):
-  return redirect('http://google.com')
+  context = {
+      'layers': None,
+      'project_name': None,
+      'xsize': 0,
+      'ysize': 0,
+      'zsize': 0,
+      'xoffset': 0,
+      'yoffset': 0,
+      'zoffset': 0,
+      'res': 0,
+      'xdownmax': 0,
+      'ydownmax': 0,
+      'starttime': 0,
+      'endtime': 0,
+      'maxres': 0,
+      'minres':0,
+      'xstart': 0,
+      'ystart': 0,
+      'zstart': 0,
+      'marker': 0,
+      'timeseries': False,
+      }
+  return render(request, 'ocpviz/viewer.html', context)
 
 # View a project dynamically generated based on token (and channel) 
 def tokenview(request, webargs):
@@ -158,7 +180,6 @@ def tokenview(request, webargs):
       'xoffset': dataset.xoffset,
       'yoffset': dataset.yoffset,
       'zoffset': dataset.zoffset,
-      'res': dataset.scalinglevels,
       'xdownmax': xdownmax,
       'ydownmax': ydownmax,
       'starttime': dataset.starttime,
@@ -177,10 +198,32 @@ def tokenview(request, webargs):
 
 # View a VizProject (pre-prepared project in the database)
 def projectview(request, webargs):
-  # AB TODO match this to above (better) 
+  # parse web args
+  # we expect /ocp/viz/project/projecttoken/res/x/y/z/ 
+  # webargs starts from the next string after project 
+  [project_name, restargs] = webargs.split('/', 1)
+  restsplit = restargs.split('/')
+
+  # initialize x,y,z,res and marker vars
+  x = None
+  y = None
+  z = None
+  res = None
+  marker = False
+
+  if len(restsplit) == 4:
+    #  res/x/y/z/ args 
+    res = int(restsplit[0])
+    x = int(restsplit[1])
+    y = int(restsplit[2])
+    z = int(restsplit[3])
+    marker = True 
+
+  else:
+    # return error 
+    return HttpResponseBadRequest('Error: Invalid REST arguments.')
+  
   # query for the project from the db
-  #[project_name, view] = webargs.split('/', 1) 
-  project_name = webargs 
   project = get_object_or_404(VizProject, pk=project_name) 
   layers = project.layers.select_related()
  
@@ -191,22 +234,18 @@ def projectview(request, webargs):
       break
 
   # calculate the lowest resolution xmax and ymax
-  xdownmax = project.xmax / 2**(project.maxres - project.minres)
-  ydownmax = project.ymax / 2**(project.maxres - project.minres) 
+  xdownmax = (project.xmax - project.xmin)/(2**project.maxres)
+  xdownmax = (project.ymax - project.ymin)/(2**project.maxres)
   
-  x = None
-  y = None
-  z = None
-
   if x is None:
     x = xdownmax/2
   if y is None:
     y = ydownmax/2
   if z is None:
     z = project.zmin
+  if res is None:
+    res = project.maxres 
   
-  marker = False 
-
   context = {
       'layers': layers,
       'project_name': project_name,
@@ -219,7 +258,7 @@ def projectview(request, webargs):
       'zoffset': project.zmin,
       'maxres': project.maxres,
       'minres':0,
-      'res': project.maxres, # AB FIXME should take from URL 
+      'res': res, 
       'resstart': project.maxres,
       'xstart': x,
       'ystart': y,

--- a/django/templates/ocpviz/viewer.html
+++ b/django/templates/ocpviz/viewer.html
@@ -216,7 +216,7 @@
       var header = '<h4>{{ project_name }}</h4><br />';
       var datainfo = '<div id="opacity-control">{% spaceless %}
         {% for layer in layers %}
-        <div class="info-layer-name"><a href="#">{{ "layer_"|add:layer.layer_name|cut:" " }}</a></div>
+        <div class="info-layer-name"><a href="#">{{ layer.layer_name|cut:" " }}</a></div>
         <div class="info-opacity-control-name">Opacity</div>
         <div id="slider">
         <span class="opacity">{{ "layer_"|add:layer.layer_name|cut:" " }}</span>


### PR DESCRIPTION
Changes:
 * Match vizproject interface to automatically generated project interface
 * Match vizproject database schema to OCP schema
 * Removed unused "required" flag from db 
 * Fix misc bugs in viewer 

**Note:** You will need to run ```python manage.py migrate ocpviz``` to update your local ocpviz db schema. Migrations have already been packaged with this push. 